### PR TITLE
fix(#10): resolve service ports and label groups in export

### DIFF
--- a/plugin/main.py
+++ b/plugin/main.py
@@ -152,10 +152,11 @@ class PolicySerializer:
 
     def __init__(self, pce: PolicyComputeEngine):
         self.pce = pce
-        self._label_cache = {}       # href -> {key, value}
-        self._label_reverse = {}     # "key:value" -> href
-        self._service_cache = {}     # href -> service dict
-        self._ip_list_cache = {}     # href -> ip_list dict
+        self._label_cache = {}        # href -> {key, value}
+        self._label_reverse = {}      # "key:value" -> href
+        self._service_cache = {}      # href -> service dict
+        self._ip_list_cache = {}      # href -> ip_list dict
+        self._label_group_cache = {}  # href -> label_group dict
 
     # ------------------------------------------------------------------
     # Cache management
@@ -203,11 +204,25 @@ class PolicySerializer:
         except Exception as e:
             log.warning("Failed to fetch IP lists: %s", e)
 
+    def refresh_label_group_cache(self):
+        """Fetch all label groups from PCE and cache href -> label_group mapping."""
+        try:
+            resp = self.pce.get(f"/sec_policy/{EXPORT_POLICY_SCOPE}/label_groups")
+            if resp.status_code == 200:
+                for lg in resp.json():
+                    href = lg.get("href", "")
+                    if href:
+                        self._label_group_cache[href] = lg
+                log.info("Cached %d label groups", len(self._label_group_cache))
+        except Exception as e:
+            log.warning("Failed to fetch label groups: %s", e)
+
     def refresh_all_caches(self):
-        """Refresh all caches (labels, services, IP lists)."""
+        """Refresh all caches (labels, services, IP lists, label groups)."""
         self.refresh_label_cache()
         self.refresh_service_cache()
         self.refresh_ip_list_cache()
+        self.refresh_label_group_cache()
 
     # ------------------------------------------------------------------
     # Label resolution helpers
@@ -252,6 +267,9 @@ class PolicySerializer:
         if "label_group" in actor:
             lg = actor["label_group"]
             href = lg.get("href", "") if isinstance(lg, dict) else ""
+            cached = self._label_group_cache.get(href)
+            if cached:
+                return {"label_group": {"name": cached.get("name", href)}}
             return {"label_group": {"href": href}}
 
         if "ip_list" in actor:
@@ -269,11 +287,14 @@ class PolicySerializer:
 
         return actor
 
-    def _resolve_service_to_yaml(self, svc: dict) -> dict:
+    def _resolve_service_to_yaml(self, svc: dict):
         """Convert a single PCE ingress_service entry to YAML format.
 
+        Returns a dict for single-port services, or a list of dicts for
+        multi-port named services (caller must flatten).
+
         PCE formats:
-          - {"href": "..."} -> service reference
+          - {"href": "..."} -> service reference (resolved with port info)
           - {"port": N, "proto": N} -> inline port/proto
           - {"port": N, "to_port": N, "proto": N} -> port range
         """
@@ -282,7 +303,33 @@ class PolicySerializer:
             href = svc["href"]
             cached = self._service_cache.get(href)
             if cached:
-                return {"name": cached.get("name", href)}
+                name = cached.get("name", href)
+                ports = cached.get("service_ports", [])
+                if len(ports) == 1:
+                    sp = ports[0]
+                    entry = {"name": name}
+                    if "port" in sp:
+                        entry["port"] = sp["port"]
+                        if sp.get("to_port") and sp["to_port"] != sp["port"]:
+                            entry["to_port"] = sp["to_port"]
+                    if "proto" in sp:
+                        entry["proto"] = _proto_num_to_name(sp["proto"])
+                    return entry
+                elif len(ports) > 1:
+                    # Expand to one entry per port so callers can check svc["port"]
+                    entries = []
+                    for sp in ports:
+                        entry = {"name": name}
+                        if "port" in sp:
+                            entry["port"] = sp["port"]
+                            if sp.get("to_port") and sp["to_port"] != sp["port"]:
+                                entry["to_port"] = sp["to_port"]
+                        if "proto" in sp:
+                            entry["proto"] = _proto_num_to_name(sp["proto"])
+                        entries.append(entry)
+                    return entries
+                # No port info (Windows-only services, etc.)
+                return {"name": name}
             return {"href": href}
 
         # Inline port/proto
@@ -323,6 +370,19 @@ class PolicySerializer:
                     return {"label": {"href": f"unresolved:{key}={value}"}}
             return actor
 
+        if "label_group" in actor:
+            lg = actor["label_group"]
+            if isinstance(lg, dict):
+                if "href" in lg:
+                    return {"label_group": {"href": lg["href"]}}
+                if "name" in lg:
+                    name = lg["name"]
+                    for href, cached in self._label_group_cache.items():
+                        if cached.get("name") == name:
+                            return {"label_group": {"href": href}}
+                    log.warning("Label group not found: %s", name)
+            return actor
+
         if "ip_list" in actor:
             ipl = actor["ip_list"]
             if isinstance(ipl, dict) and "name" in ipl:
@@ -346,13 +406,15 @@ class PolicySerializer:
           - {"port": N, "to_port": N, "proto": "tcp"} -> port range
           - {"name": "..."} -> service reference by name
         """
-        if "name" in svc and "port" not in svc:
+        # Name takes priority — embedded port/proto is informational metadata added
+        # during export and must not override the service reference on import.
+        if "name" in svc:
             name = svc["name"]
             for href, cached in self._service_cache.items():
                 if cached.get("name") == name:
                     return {"href": href}
-            log.warning("Service not found: %s", name)
-            return svc
+            log.warning("Service not found by name: %s — falling back to inline port", name)
+            # Fall through to inline port handling if name lookup fails
 
         if "port" in svc:
             result = {
@@ -472,7 +534,14 @@ class PolicySerializer:
         """Convert a single PCE rule to YAML format."""
         consumers = [self._resolve_actor_to_yaml(a) for a in rule.get("consumers", [])]
         providers = [self._resolve_actor_to_yaml(a) for a in rule.get("providers", [])]
-        services = [self._resolve_service_to_yaml(s) for s in rule.get("ingress_services", [])]
+        # _resolve_service_to_yaml returns a list for multi-port named services — flatten.
+        services = []
+        for s in rule.get("ingress_services", []):
+            resolved = self._resolve_service_to_yaml(s)
+            if isinstance(resolved, list):
+                services.extend(resolved)
+            else:
+                services.append(resolved)
 
         # Use description if present; generate a readable name from content otherwise.
         # PCE hrefs ("/orgs/...") are never useful as names.


### PR DESCRIPTION
Closes #10

## Changes

### `plugin/main.py` — `_resolve_service_to_yaml()`

Before: service hrefs resolved to just `{name: ntp}`, losing port/proto.

After:
- **Single-port** service: `{name: ntp, port: 123, proto: udp}`
- **Multi-port** service: expanded to one entry per port/proto pair  
  (e.g. `mysql` with TCP+UDP → two entries `{name: mysql, port: 3306, proto: tcp}` and `{name: mysql, port: 3306, proto: udp}`)
- **No-port** services (Windows-only): `{name: ...}` unchanged — no regression

### `plugin/main.py` — `_export_rule_to_yaml()`

Flattens multi-port expansions from `_resolve_service_to_yaml` into the flat `services:` list.

### `plugin/main.py` — `_resolve_service_to_pce()`

Name lookup now takes priority even when `port` is present in the YAML entry (the embedded port is informational metadata, not a new inline rule). Falls back to inline port/proto only if the service name is not found in the cache.

### `plugin/main.py` — Label group resolution

- `_label_group_cache` added; `refresh_label_group_cache()` fetches `/sec_policy/{scope}/label_groups`
- `_resolve_actor_to_yaml`: label group hrefs → `{label_group: {name: ...}}`
- `_resolve_actor_to_pce`: label group names → hrefs on import

## Impact on security checks

With ports embedded in named service entries, `security-check.py` `check_ports()` (`svc.get("port")`) now correctly evaluates:
- SEC-003 (insecure protocols): `rdp` → port 3389 flagged
- SEC-005 (RDP/SMB): detected via embedded port
- SEC-006 (database ports): mysql/postgresql/mssql flagged

No changes to `security-check.py` required — it already reads `svc["port"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)