### PR TITLE
feat: provider-centric cross-scope authoring + services provisioning fix

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -259,6 +259,16 @@ rules:
       IP lists with /8 or broader CIDRs
     message: "Very broad CIDR range. Consider narrowing."
 
+  - id: SEC-010
+    name: "Extra-scope rule provider-centric placement"
+    severity: medium
+    action: warn
+    check: |
+      Extra-scope rules must be authored in the provider's scope. Flags a rule
+      whose consumer app equals the enclosing scope, or whose providers name a
+      different app than the scope, plus the deprecated requester/target schema.
+    message: "Author cross-scope rules in the provider's inbound/ file."
+
 # Override: rules that are always allowed (bypass security checks)
 exemptions:
   - ruleset_pattern: "coreservices"
@@ -642,28 +652,35 @@ rules:
     enabled: true
 ```
 
-### Cross-scope rule request
+### Cross-scope rule (provider-centric, authored once)
+Scopes are provider-centric, so the cross-scope rule is authored as a single file in
+the **provider's** scope. The requester-side `cross-scope/to-shareddb.yaml` is generated
+from this file and is never authored by hand.
 ```yaml
-name: payments-to-shareddb
+# scopes/app-shareddb_env-prod/inbound/from-payments.yaml
+name: shareddb-prod-inbound-from-payments
 description: "Payments app needs access to shared database"
 type: extra-scope
-
-requester:
-  scope: payments-prod
-  consumers:
-    - label: {role: processing}
-
-target:
-  scope: shareddb-prod
-  providers:
-    - label: {role: db}
-
-services:
-  - {port: 5432, proto: tcp}
+enabled: true
 
 justification: "Payment processing requires direct DB access for transaction writes"
 requested_by: alice@example.com
 requested_date: "2026-04-26"
+
+scopes:
+  - - label: {app: shareddb}
+    - label: {env: prod}
+
+rules:
+  - name: payments-to-db
+    unscoped_consumers: true
+    consumers:
+      - label: {app: payments}
+      - label: {role: processing}
+    providers:
+      - label: {role: db}
+    services:
+      - {port: 5432, proto: tcp}
 ```
 
 ### CODEOWNERS
@@ -674,13 +691,15 @@ ip-lists/               @org/security-team
 services/               @org/security-team
 
 # Per-scope ownership
-scopes/payments-prod/   @org/payments-team
-scopes/shareddb-prod/   @org/database-team
-scopes/ordering-prod/   @org/ordering-team
+scopes/app-payments_env-prod/   @org/payments-team
+scopes/app-shareddb_env-prod/   @org/database-team
+scopes/app-ordering_env-prod/   @org/ordering-team
 
-# Cross-scope rules require BOTH teams
-scopes/*/cross-scope/   @org/security-team
+# Cross-scope: the canonical rule lives in the provider's inbound/ — the provider
+# scope owner (per-scope line above) plus security approve. The requester is the
+# PR author. cross-scope/ holds generated, read-only requester-side views.
 scopes/*/inbound/       @org/security-team
+scopes/*/cross-scope/   @org/security-team
 ```
 
 ---
@@ -689,17 +708,17 @@ scopes/*/inbound/       @org/security-team
 
 ```
 1. Team A (payments) creates a PR:
-   - Adds: scopes/payments-prod/cross-scope/to-shareddb.yaml
-   - Adds: scopes/shareddb-prod/inbound/from-payments.yaml (mirror)
+   - Adds the single canonical file in the PROVIDER's scope:
+     scopes/app-shareddb_env-prod/inbound/from-payments.yaml
 
 2. GitHub Actions validate-policy runs:
-   - Security check: flags as HIGH (cross-scope, DB access)
+   - Security check: flags as HIGH (cross-scope, DB access); SEC-010 verifies placement
    - Traffic evidence: queries PCE, finds 891 blocked flows → JUSTIFIED
    - Posts beautiful PR comment with all details
 
 3. CODEOWNERS triggers reviews:
-   - @org/payments-team → auto-approved (their own scope)
-   - @org/database-team → MUST review (touches their inbound dir)
+   - payments engineer is the PR author (consent implicit — requester centric)
+   - @org/database-team → MUST review (the provider — owns shareddb's inbound)
    - @org/security-team → MUST review (cross-scope policy)
 
 4. Team B (database) reviews:
@@ -715,6 +734,7 @@ scopes/*/inbound/       @org/security-team
 6. PR merges → provision-policy runs:
    - Creates the extra-scope ruleset on PCE draft
    - Provisions to active
+   - Regenerates the requester-side cross-scope/to-shareddb.yaml view
    - Comments with result
 
 7. Full audit trail in Git:

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ illumio-policy/                         ← your policy repository
 │   │   ├── _scope.yaml                 ← label definitions + owner team
 │   │   ├── intra-rules.yaml            ← within-scope rules
 │   │   └── cross-scope/
-│   │       └── to-shareddb.yaml        ← rules reaching outside this scope
+│   │       └── to-shareddb.yaml        ← GENERATED view of outbound deps (read-only)
 │   └── app-shareddb_env-prod/
 │       ├── _scope.yaml
 │       ├── intra-rules.yaml
 │       └── inbound/
-│           └── from-payments.yaml      ← mirror of payments' cross-scope rule
+│           └── from-payments.yaml      ← canonical cross-scope rule (authored here)
 ├── ip-lists/
 │   ├── any.yaml
 │   ├── rfc1918.yaml
@@ -119,11 +119,11 @@ Policy is organized around **scopes** — pairs of labels (typically `app` + `en
 | Rule Type | Location | Who Must Approve |
 |---|---|---|
 | **Intra-scope** | `scopes/{scope}/intra-rules.yaml` | Scope owner team |
-| **Cross-scope** (requester side) | `scopes/{scope}/cross-scope/to-{target}.yaml` | Requester team + target team + security |
-| **Cross-scope** (target side) | `scopes/{scope}/inbound/from-{requester}.yaml` | Same as above |
+| **Cross-scope** (canonical) | `scopes/{provider}/inbound/from-{requester}.yaml` | Provider scope owner + security |
+| **Cross-scope** (requester view) | `scopes/{requester}/cross-scope/to-{provider}.yaml` | _Generated, read-only — not authored or reviewed_ |
 | **Global** (unscoped) | `scopes/_global/` | Security team only |
 
-This structure makes it impossible for Team A to add a rule into Team B's scope without Team B's explicit GitHub review and approval.
+This structure makes it impossible for Team A to add a rule into Team B's scope without Team B's explicit GitHub review and approval. See [Cross-Scope Dependencies (Provider-Centric)](#cross-scope-dependencies-provider-centric) for why the canonical rule lives in the provider's scope.
 
 ### The Pull Request Workflow
 
@@ -132,15 +132,15 @@ This structure makes it impossible for Team A to add a rule into Team B's scope 
 2. Opens pull request
 3. GitHub Actions pipeline runs automatically:
    ├── YAML syntax validation
-   ├── Security policy checks (8 configurable rules)
+   ├── Security policy checks (9 enforced rules)
    ├── Traffic evidence query (PCE Explorer API)
    ├── Policy resolution (which workloads are affected)
    ├── Firewall change request generation
    └── PR comment posted with full findings
 4. CODEOWNERS enforces required reviewers:
-   ├── Scope owner (payments-team)
-   ├── Target scope owner (database-team, for cross-scope)
-   └── Security team (for cross-scope and global)
+   ├── Scope owner (the provider team — owns the workloads being protected)
+   ├── Security team (for cross-scope and global)
+   └── (requester is the PR author; their consent is implicit in opening the PR)
 5. All checks pass + all reviewers approve → merge unblocked
 6. Merge to main → provision-policy.yml runs → PCE draft updated
 7. Full audit trail: Git diff + PR + reviews + merge timestamp
@@ -158,7 +158,7 @@ Every changed `.yaml` file is parsed. Deleted files are skipped gracefully. Inva
 
 ### Stage 2 — Security Checks
 
-Eight configurable rules evaluated against the policy diff:
+Nine enforced rules evaluated against the policy diff:
 
 | Rule | Severity | What It Catches |
 |---|---|---|
@@ -170,6 +170,9 @@ Eight configurable rules evaluated against the policy diff:
 | **SEC-006** | ⚠️ High | Database ports (5432, 3306, 1433, 1521, 27017) exposed to non-role consumers |
 | **SEC-007** | ⚠️ Medium | IP lists with /8 or broader CIDR (e.g. 10.0.0.0/8 = 16 million IPs) |
 | **SEC-008** | ⚠️ High | All Workloads or Any IP as consumer without a role-specific provider |
+| **SEC-010** | ⚠️ Medium | Extra-scope rule authored in the wrong scope (see [provider-centric cross-scope](#cross-scope-dependencies-provider-centric)) |
+
+<sub>SEC-009 is reserved in `.illumio/security-rules.yaml` for an HTTP-without-HTTPS check that is not yet enforced.</sub>
 
 Rules are **fully configurable** in `.illumio/security-rules.yaml`. Each rule supports exemptions — for example, exempting a core-services scope from SEC-005 when SMB is legitimately required for Active Directory.
 
@@ -289,16 +292,48 @@ scopes/app-ordering_env-prod/    @org/ordering-team
 
 **Cross-scope rule example:** Payments engineer adds a rule from payments to shareddb.
 
-1. PR touches `cross-scope/to-shareddb.yaml` and `inbound/from-payments.yaml`
+1. PR adds the **single canonical file** `scopes/app-shareddb_env-prod/inbound/from-payments.yaml`
 2. CODEOWNERS matches trigger required reviews from:
-   - `@org/payments-team` (requester — author auto-approves)
-   - `@org/database-team` (target — must explicitly approve)
+   - `@org/database-team` (provider — owns the shareddb workloads being reached, must approve)
    - `@org/security-team` (cross-scope pattern — must explicitly approve)
+   - the payments engineer is the **PR author** — their consent is implicit
 3. PR comment shows 891 blocked flows justifying the rule
 4. Database team reviews the evidence, approves
 5. Security team validates least-privilege, approves
 6. GitHub unblocks merge → plugin provisions to PCE
-7. Git records: author, reviewers, merge timestamp, exact diff
+7. On merge, the requester-side `scopes/app-payments_env-prod/cross-scope/to-shareddb.yaml` is regenerated for discoverability
+8. Git records: author, reviewers, merge timestamp, exact diff
+
+### Cross-Scope Dependencies (Provider-Centric)
+
+Illumio scopes are **provider-centric**: a ruleset's scope defines whose workloads are
+being *protected* — the providers. An extra-scope (cross-scope) rule says "consumers
+from outside this scope may reach providers inside it," so the rule belongs to the
+**provider's** scope, and the provider team owns who is allowed in.
+
+Because of this, a cross-scope dependency is authored **once**, as a single file in the
+provider's scope:
+
+```
+scopes/app-shareddb_env-prod/inbound/from-payments.yaml   ← authored, canonical, provisioned
+```
+
+The requester team (payments) is the PR author; their consent is implicit in opening the
+PR. The provider team (database) + security are the required approvers via CODEOWNERS on
+`inbound/`. There is no second file to author and no redundant mirror to keep in sync.
+
+For discoverability from the requester's side, the pipeline **generates** a read-only view
+on merge:
+
+```
+scopes/app-payments_env-prod/cross-scope/to-shareddb.yaml   ← GENERATED (generated: true)
+```
+
+Generated files carry `generated: true`; they are never provisioned to the PCE and are
+skipped by the security checks. **SEC-010** enforces this model: it flags an extra-scope
+rule authored in the wrong scope (e.g. filed under the consumer's scope, or with providers
+naming a different app than the enclosing scope), and flags the deprecated hand-authored
+`requester:`/`target:` courtesy schema.
 
 ---
 
@@ -362,27 +397,35 @@ deny_rules:
 
 ### Cross-Scope Rule
 
+Authored **once** in the provider's scope (provider-centric). The scope is the provider
+(`shareddb`); the external consumer (`payments`) is allowed in via `unscoped_consumers`.
+The requester-side `cross-scope/to-shareddb.yaml` is generated from this file — do not
+author it by hand.
+
 ```yaml
-# scopes/app-payments_env-prod/cross-scope/to-shareddb.yaml
-name: payments-to-shareddb
+# scopes/app-shareddb_env-prod/inbound/from-payments.yaml
+name: shareddb-prod-inbound-from-payments
 type: extra-scope
-
-requester:
-  scope: payments-prod
-  consumers:
-    - label: {role: processing}
-
-target:
-  scope: shareddb-prod
-  providers:
-    - label: {role: db}
-
-services:
-  - {port: 5432, proto: tcp}
+enabled: true
 
 justification: "Payment processing requires direct DB write access for transaction commits"
 requested_by: alice@example.com
 requested_date: "2026-04-26"
+
+scopes:
+  - - label: {app: shareddb}
+    - label: {env: prod}
+
+rules:
+  - name: payments-to-db
+    unscoped_consumers: true          # consumers are outside this (shareddb) scope
+    consumers:
+      - label: {app: payments}        # the external requester
+      - label: {role: processing}
+    providers:
+      - label: {role: db}             # in-scope provider workloads
+    services:
+      - {port: 5432, proto: tcp}
 ```
 
 ### Actor Formats

--- a/TODO.md
+++ b/TODO.md
@@ -25,3 +25,41 @@
 - The drift-check script can reuse the `DriftDetector` logic from `plugin/main.py` — extract it into `action/scripts/drift-check.py`
 - The workflow should skip opening a duplicate issue if one is already open with the same label
 - Consider making the workflow also triggerable via `workflow_dispatch` for on-demand checks
+
+## Provider-Centric Cross-Scope Authoring
+
+**Problem:** Cross-scope dependencies originally required authoring **two** files — a
+requester-side `cross-scope/to-<target>.yaml` and a target-side
+`inbound/from-<requester>.yaml`. This was redundant:
+- The requester-side file was never provisioned (it has no `rules:`, so `provision.py` skips it) — it was pure documentation.
+- Illumio scopes are **provider-centric**: an extra-scope rule protects the provider's workloads, so the canonical rule belongs in the provider's scope. The requester-side file added authoring toil and a mirror to keep in sync, with no policy value.
+
+**Solution:** Author the cross-scope rule **once** in the provider's scope; generate the requester-side view.
+
+1. Canonical rule lives at `scopes/app-<provider>_env-<env>/inbound/from-<requester>.yaml` (standard ruleset schema, `unscoped_consumers: true`). The provider team + security own/approve it via CODEOWNERS on `inbound/`; the requester is the PR author.
+2. `action/scripts/generate-cross-scope-docs.py` derives the read-only requester-side `cross-scope/to-<provider>.yaml` (carries `generated: true`, never provisioned, skipped by security checks). Regenerated + committed on merge by `provision-policy.yml`.
+3. `SEC-010` enforces the model: extra-scope rules must be authored in the provider's scope (providers in-scope, consumers external), and the deprecated `requester:`/`target:` schema is flagged.
+
+**Benefits:**
+- One file to author, no redundant mirror to keep in sync.
+- Approval falls out of the data model: the provider (whose workloads are reached) approves; the requester just opens the PR.
+- Requester-side discoverability preserved via the generated view.
+
+**Notes:**
+- Justification metadata (`justification`, `requested_by`, `requested_date`) now lives on the canonical inbound file (also fixes a latent SEC-004 warning that fired on inbound files lacking justification).
+- Requester environment is assumed to match the provider's; revisit if cross-env dependencies are needed.
+- Implemented in this change — kept here as the design record.
+
+## Provision Net-New Services to the PCE (Git → PCE)
+
+**Problem:** `provision.py` only routed `ip-lists/` and `scopes/`. A net-new named service
+authored in Git under `services/` was never created on the PCE, and any rule referencing it
+by name failed resolution — a hole in the "Git is the source of truth" story.
+
+**Solution (implemented in this change):** Added `provision_service` (create/update by name
+against the PCE draft), routed `services/` in `main()`, ordered services before rulesets, and
+refreshed the service cache so rules resolve newly-created services. Service deletions handled
+in `delete_object`.
+
+**Notes:**
+- Follow-up: `plugin/main.py`'s `import_yaml_to_*` functions are dead code — the daemon's `SYNC_MODE=provision` never wires to a Git→PCE write path (only `provision.py` in the Action does). Decide whether to wire it or remove the dead converters.

--- a/action/scripts/generate-cross-scope-docs.py
+++ b/action/scripts/generate-cross-scope-docs.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Generate requester-side cross-scope courtesy files from canonical inbound rules.
+
+Scopes are provider-centric: a cross-scope (extra-scope) rule is authored ONCE in
+the provider's scope at
+
+    scopes/app-<provider>_env-<env>/inbound/from-<requester>.yaml
+
+That file is the source of truth and the only one provisioned to the PCE. This
+script derives the requester-side discoverability file
+
+    scopes/app-<requester>_env-<env>/cross-scope/to-<provider>.yaml
+
+so a requester team can see its outbound dependencies in its own directory.
+Generated files carry `generated: true`; security-check.py and provision.py skip
+them. The requester's environment is assumed to match the provider's.
+
+Usage:
+  python3 generate-cross-scope-docs.py [--root .] [--check]
+
+  --check  Do not write; exit 1 if any courtesy file is missing or out of date
+           (use in the validation pipeline). Without --check, write/refresh files.
+"""
+
+import argparse
+import glob
+import os
+import sys
+
+import yaml
+
+HEADER = (
+    "# GENERATED FILE — DO NOT EDIT.\n"
+    "# Source of truth: {source}\n"
+    "# Regenerate: python3 .github/scripts/generate-cross-scope-docs.py\n"
+    "\n"
+)
+
+
+def _scope_app_env(data):
+    app = env = None
+    for scope_entry in data.get("scopes", []):
+        for item in scope_entry:
+            if isinstance(item, dict) and isinstance(item.get("label"), dict):
+                lbl = item["label"]
+                app = lbl.get("app", app)
+                env = lbl.get("env", env)
+    return app, env
+
+
+def _dedup(items):
+    """Order-preserving dedup of a list of dicts."""
+    seen = set()
+    out = []
+    for it in items:
+        key = repr(sorted(it.items())) if isinstance(it, dict) else repr(it)
+        if key not in seen:
+            seen.add(key)
+            out.append(it)
+    return out
+
+
+def derive(inbound_data, inbound_path):
+    """Return (out_path, courtesy_dict) for one canonical inbound file."""
+    provider_app, env = _scope_app_env(inbound_data)
+    # Fall back to the directory name (scopes/app-<app>_env-<env>/inbound/...)
+    parts = inbound_path.replace("\\", "/").split("/")
+    if (provider_app is None or env is None) and len(parts) >= 3:
+        dirname = parts[-3]  # app-<app>_env-<env>
+        if dirname.startswith("app-") and "_env-" in dirname:
+            app_part, env_part = dirname[len("app-"):].split("_env-", 1)
+            provider_app = provider_app or app_part
+            env = env or env_part
+
+    fname = os.path.basename(inbound_path)
+    req_app = fname[len("from-"):].rsplit(".", 1)[0] if fname.startswith("from-") else fname.rsplit(".", 1)[0]
+
+    consumers, providers, services = [], [], []
+    for rule in inbound_data.get("rules", []):
+        if not isinstance(rule, dict):
+            continue
+        for c in rule.get("consumers", []):
+            # Keep within-scope selectors (role, etc.); drop the external app label.
+            if isinstance(c, dict) and isinstance(c.get("label"), dict) and set(c["label"]) == {"app"}:
+                continue
+            consumers.append(c)
+        providers.extend(rule.get("providers", []))
+        services.extend(rule.get("services", []))
+
+    courtesy = {
+        "generated": True,
+        "name": f"{req_app}-to-{provider_app}",
+        "description": f"Generated cross-scope dependency: {req_app} → {provider_app}. See source.",
+        "type": "extra-scope",
+        "source": inbound_path,
+        "requester": {"scope": f"{req_app}-{env}", "consumers": _dedup(consumers)},
+        "target": {"scope": f"{provider_app}-{env}", "providers": _dedup(providers)},
+        "services": _dedup(services),
+    }
+    for meta in ("justification", "requested_by", "requested_date"):
+        if inbound_data.get(meta) is not None:
+            courtesy[meta] = inbound_data[meta]
+
+    out_path = f"scopes/app-{req_app}_env-{env}/cross-scope/to-{provider_app}.yaml"
+    return out_path, courtesy
+
+
+def render(courtesy):
+    """Render a courtesy dict to YAML text with the GENERATED header."""
+    body = yaml.safe_dump(courtesy, sort_keys=False, default_flow_style=False, allow_unicode=True)
+    return HEADER.format(source=courtesy.get("source", "")) + body
+
+
+def find_inbound_files(root):
+    return sorted(glob.glob(os.path.join(root, "scopes", "*", "inbound", "from-*.yaml")))
+
+
+def generate(root=".", check=False):
+    """Write (or, with check=True, verify) all requester-side courtesy files.
+
+    Returns the list of root-relative paths that were written (or that are stale,
+    in check mode). An empty list means everything is already up to date.
+    """
+    changed = []
+    for inbound_abs in find_inbound_files(root):
+        rel_inbound = os.path.relpath(inbound_abs, root).replace("\\", "/")
+        with open(inbound_abs) as f:
+            data = yaml.safe_load(f) or {}
+        if not isinstance(data, dict) or data.get("generated"):
+            continue
+        out_rel, courtesy = derive(data, rel_inbound)
+        desired = render(courtesy)
+        out_abs = os.path.join(root, out_rel)
+        current = None
+        if os.path.exists(out_abs):
+            with open(out_abs) as f:
+                current = f.read()
+        if current == desired:
+            continue
+        changed.append(out_rel)
+        if not check:
+            os.makedirs(os.path.dirname(out_abs), exist_ok=True)
+            with open(out_abs, "w") as f:
+                f.write(desired)
+    return changed
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--check", action="store_true",
+                        help="verify courtesy files are current; exit 1 on drift")
+    args = parser.parse_args()
+
+    changed = generate(args.root, check=args.check)
+    if args.check:
+        if changed:
+            print("Cross-scope courtesy files are out of date — run generate-cross-scope-docs.py:")
+            for c in changed:
+                print(f"  {c}")
+            sys.exit(1)
+        print("Cross-scope courtesy files up to date")
+        return
+    if changed:
+        for c in changed:
+            print(f"  generated {c}")
+        print(f"Generated {len(changed)} cross-scope courtesy file(s)")
+    else:
+        print("Cross-scope courtesy files already up to date")
+
+
+if __name__ == "__main__":
+    main()

--- a/action/scripts/provision.py
+++ b/action/scripts/provision.py
@@ -125,6 +125,48 @@ def provision_ip_list(pce, filepath, data, label_map, ipl_map=None):
         return "created", name
 
 
+def provision_service(pce, filepath, data):
+    """Create or update a named service on the PCE draft (Git -> PCE).
+
+    Net-new services authored in Git must be created so that rules referencing
+    them by name resolve. Matches an existing draft service by name.
+    """
+    name = data["name"]
+    proto_map = {"tcp": 6, "udp": 17, "icmp": 1}
+    service_ports = []
+    for sp in data.get("service_ports", []):
+        if not isinstance(sp, dict):
+            continue
+        entry = {}
+        if "port" in sp:
+            entry["port"] = sp["port"]
+        if "to_port" in sp:
+            entry["to_port"] = sp["to_port"]
+        proto = sp.get("proto", "tcp")
+        entry["proto"] = proto_map.get(proto, proto) if isinstance(proto, str) else proto
+        service_ports.append(entry)
+
+    body = {
+        "name": name,
+        "description": data.get("description") or "",
+        "service_ports": service_ports,
+    }
+    existing = pce.get("/sec_policy/draft/services").json()
+    found = next((s for s in existing if s["name"] == name), None)
+    if found:
+        pce.put(found["href"], json=body)
+        return "updated", name
+    else:
+        pce.post("/sec_policy/draft/services", json=body)
+        return "created", name
+
+
+def _refresh_service_cache(pce, svc_map):
+    """Merge current draft services into svc_map so rules resolve newly-created services."""
+    for s in pce.get("/sec_policy/draft/services").json():
+        svc_map[s["name"]] = s["href"]
+
+
 def provision_ruleset(pce, filepath, data, label_map, svc_map, ipl_map=None):
     name = data["name"]
 
@@ -181,6 +223,14 @@ def delete_object(pce, filepath):
                 pce.delete(ipl["href"])
                 return "deleted", ipl["name"]
 
+    elif filepath.startswith("services/"):
+        existing = pce.get("/sec_policy/draft/services").json()
+        for s in existing:
+            sanitized = s["name"].lower().replace(" ", "-").replace("/", "-")
+            if sanitized == basename or s["name"] == basename:
+                pce.delete(s["href"])
+                return "deleted", s["name"]
+
     elif filepath.startswith("scopes/"):
         existing = pce.get("/sec_policy/draft/rule_sets", params={"max_results": 5000}).json()
         for rs in existing:
@@ -222,6 +272,18 @@ def main():
     label_map, svc_map, ipl_map = build_caches(pce)
 
     files = [f.strip() for f in changed_raw.split("\n") if f.strip()]
+
+    # Provision dependencies before dependents: ip-lists and services must exist
+    # before the rulesets that reference them by name can resolve.
+    def _order(fp):
+        if fp.startswith("ip-lists/"):
+            return 0
+        if fp.startswith("services/"):
+            return 1
+        if fp.startswith("scopes/"):
+            return 2
+        return 3
+    files.sort(key=_order)
     print(f"Processing {len(files)} changed files...")
 
     created = 0
@@ -229,6 +291,8 @@ def main():
     deleted = 0
     errors = []
     processed_files = []
+    services_dirty = False  # a service was created/updated this run
+    cache_refreshed = False  # svc_map refreshed before scopes are processed
 
     for filepath in files:
         if "_scope.yaml" in filepath or ".gitkeep" in filepath:
@@ -259,12 +323,24 @@ def main():
         if not isinstance(data, dict) or "name" not in data:
             continue
 
+        # Generated courtesy/doc files are derived from canonical policy — skip them.
+        if data.get("generated"):
+            continue
+
         try:
             if filepath.startswith("ip-lists/"):
                 action, name = provision_ip_list(pce, filepath, data, label_map, ipl_map)
+            elif filepath.startswith("services/"):
+                action, name = provision_service(pce, filepath, data)
+                if action in ("created", "updated"):
+                    services_dirty = True
             elif filepath.startswith("scopes/"):
                 if "rules" not in data:
                     continue
+                # Pick up services created earlier this run before resolving the ruleset.
+                if services_dirty and not cache_refreshed:
+                    _refresh_service_cache(pce, svc_map)
+                    cache_refreshed = True
                 action, name = provision_ruleset(pce, filepath, data, label_map, svc_map, ipl_map)
             else:
                 continue

--- a/action/scripts/security-check.py
+++ b/action/scripts/security-check.py
@@ -83,6 +83,21 @@ DEFAULT_RULES = [
             "Restrict consumers to a specific role or label."
         ),
     },
+    # SEC-009 (HTTP-without-HTTPS) is defined in .illumio/security-rules.yaml as a
+    # config-only stub with no implementation here — do not reuse this id.
+    {
+        "id": "SEC-010",
+        "name": "Extra-scope rule provider-centric placement",
+        "severity": "medium",
+        "action": "warn",
+        "description": (
+            "Scopes are provider-centric: an extra-scope (cross-scope) rule protects the "
+            "provider's workloads, so it must be authored in the provider's scope. The rule's "
+            "providers belong to the enclosing scope; consumers are external. A rule whose "
+            "consumer app matches the enclosing scope, or whose providers name a different app "
+            "than the scope, is filed in the wrong directory."
+        ),
+    },
 ]
 
 
@@ -218,6 +233,66 @@ def check_broad_consumer(rule_data: dict) -> bool:
     return True
 
 
+def _scope_app_env(data: dict):
+    """Return (app, env) from the ruleset's scope labels, or (None, None) if global."""
+    app = env = None
+    for scope_entry in data.get("scopes", []):
+        for item in scope_entry:
+            if isinstance(item, dict) and isinstance(item.get("label"), dict):
+                lbl = item["label"]
+                if "app" in lbl:
+                    app = lbl["app"]
+                if "env" in lbl:
+                    env = lbl["env"]
+    return app, env
+
+
+def _label_apps(actors) -> set:
+    """Collect the set of 'app' label values among a list of consumer/provider actors."""
+    apps = set()
+    for a in actors:
+        if isinstance(a, dict) and isinstance(a.get("label"), dict) and "app" in a["label"]:
+            apps.add(a["label"]["app"])
+    return apps
+
+
+def check_extra_scope_placement(data: dict):
+    """SEC-010: extra-scope rules must live in the provider's scope.
+
+    Returns a list of (rule_name, reason) tuples. An extra-scope rule is correctly
+    placed when its providers belong to the enclosing scope and its consumers are
+    external. Flags, per rule:
+      - consumer app == the enclosing scope app (rule filed in the consumer's scope
+        instead of the provider's), or
+      - providers explicitly name a different app than the enclosing scope.
+    Provider labels with no 'app' (e.g. just a role) are implicitly in-scope and OK.
+    """
+    problems = []
+    scope_app, _scope_env = _scope_app_env(data)
+    if not scope_app:
+        return problems  # global / unscoped ruleset — placement check does not apply
+    for rule in data.get("rules", []):
+        if not isinstance(rule, dict) or not rule.get("unscoped_consumers"):
+            continue
+        name = rule.get("name", "(unnamed)")
+        consumer_apps = _label_apps(rule.get("consumers", []))
+        provider_apps = _label_apps(rule.get("providers", []))
+        if scope_app in consumer_apps:
+            problems.append((
+                name,
+                f"consumer app '{scope_app}' equals the enclosing scope — author this rule "
+                "in the provider's scope, not the consumer's",
+            ))
+        elif provider_apps and scope_app not in provider_apps:
+            other = sorted(provider_apps)[0]
+            problems.append((
+                name,
+                f"providers are app '{other}' but the scope is app '{scope_app}' — extra-scope "
+                f"rules belong in the provider's scope (app '{other}')",
+            ))
+    return problems
+
+
 def _is_rule_applicable(rule_cfg: dict, is_scoped: bool) -> bool:
     """Check scope_filter to decide if a rule applies to this ruleset."""
     scope_filter = rule_cfg.get("scope_filter", "")
@@ -265,6 +340,11 @@ def analyze_file(filepath, rules, exemptions):
         return findings
 
     if not isinstance(data, dict):
+        return findings
+
+    # Generated courtesy/doc files are derived from canonical policy, never authored
+    # or provisioned — they are not subject to security checks.
+    if data.get("generated"):
         return findings
 
     is_scoped = _ruleset_is_scoped(data)
@@ -419,6 +499,36 @@ def analyze_file(filepath, rules, exemptions):
                             f"Rule '{rule_name}' has a broad consumer (All Workloads or catch-all IP list) "
                             "with no role constraint on providers"
                         ),
+                    })
+
+    # SEC-010: extra-scope rules must be authored in the provider's scope
+    if ("SEC-010" not in exempt_rules and "SEC-010" in rule_cfg_by_id
+            and "scopes" in filepath):
+        cfg = rule_cfg_by_id["SEC-010"]
+        if not _is_scope_exempt(data, exemptions, "SEC-010"):
+            # Hand-authored requester/target courtesy schema is deprecated — the rule
+            # should live once in the provider's inbound/ file (the requester-side file
+            # is generated). Detect it by the requester/target shape with no rules.
+            if data.get("type") == "extra-scope" and "target" in data and "rules" not in data:
+                findings.append({
+                    "file": filepath,
+                    "rule_id": "SEC-010",
+                    "severity": cfg.get("severity", "medium"),
+                    "action": cfg.get("action", "warn"),
+                    "message": (
+                        "Deprecated cross-scope authoring format (requester/target). Author the "
+                        "rule once in the target scope's inbound/ file; the requester-side file "
+                        "is generated by generate-cross-scope-docs.py."
+                    ),
+                })
+            else:
+                for rule_name, reason in check_extra_scope_placement(data):
+                    findings.append({
+                        "file": filepath,
+                        "rule_id": "SEC-010",
+                        "severity": cfg.get("severity", "medium"),
+                        "action": cfg.get("action", "warn"),
+                        "message": f"Extra-scope rule '{rule_name}' misplaced: {reason}",
                     })
 
     return findings

--- a/action/scripts/tests/_loader.py
+++ b/action/scripts/tests/_loader.py
@@ -1,0 +1,15 @@
+"""Load hyphenated pipeline scripts as importable modules for tests."""
+import importlib.util
+import pathlib
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1]
+
+
+def load(filename):
+    """Import a script from action/scripts/ by filename (handles hyphens)."""
+    path = SCRIPTS / filename
+    mod_name = filename.replace("-", "_").replace(".py", "")
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod

--- a/action/scripts/tests/test_generate_cross_scope.py
+++ b/action/scripts/tests/test_generate_cross_scope.py
@@ -1,0 +1,96 @@
+"""Tests for generate-cross-scope-docs.py — derive requester-side courtesy files."""
+import yaml
+
+from _loader import load
+
+gen = load("generate-cross-scope-docs.py")
+
+INBOUND = {
+    "name": "ad-prod-inbound-from-payments",
+    "description": "Inbound from payments scope",
+    "type": "extra-scope",
+    "enabled": True,
+    "justification": "Kerberos/LDAP for PCI role enforcement.",
+    "requested_by": "alice@example.com",
+    "requested_date": "2026-04-15",
+    "scopes": [[{"label": {"app": "ad"}}, {"label": {"env": "prod"}}]],
+    "rules": [
+        {
+            "name": "payments-kerberos",
+            "unscoped_consumers": True,
+            "consumers": [{"label": {"app": "payments"}}, {"label": {"role": "processing"}}],
+            "providers": [{"label": {"role": "dc"}}],
+            "services": [{"port": 88, "proto": "tcp"}, {"port": 464, "proto": "tcp"}],
+        },
+        {
+            "name": "payments-ldap",
+            "unscoped_consumers": True,
+            "consumers": [{"label": {"app": "payments"}}, {"label": {"role": "processing"}}],
+            "providers": [{"label": {"role": "dc"}}],
+            "services": [{"port": 389, "proto": "tcp"}, {"port": 636, "proto": "tcp"}],
+        },
+    ],
+}
+
+INBOUND_PATH = "scopes/app-ad_env-prod/inbound/from-payments.yaml"
+
+
+def test_derive_output_path():
+    out_path, _courtesy = gen.derive(INBOUND, INBOUND_PATH)
+    assert out_path == "scopes/app-payments_env-prod/cross-scope/to-ad.yaml"
+
+
+def test_derive_scopes_and_actors():
+    _out, c = gen.derive(INBOUND, INBOUND_PATH)
+    assert c["generated"] is True
+    assert c["source"] == INBOUND_PATH
+    assert c["requester"]["scope"] == "payments-prod"
+    assert c["target"]["scope"] == "ad-prod"
+    # requester consumers drop the app label (within-scope selectors only)
+    assert c["requester"]["consumers"] == [{"label": {"role": "processing"}}]
+    assert c["target"]["providers"] == [{"label": {"role": "dc"}}]
+    # justification metadata carried over
+    assert c["justification"] == INBOUND["justification"]
+    assert c["requested_by"] == "alice@example.com"
+
+
+def test_derive_unions_services_across_rules():
+    _out, c = gen.derive(INBOUND, INBOUND_PATH)
+    ports = sorted((s["port"], s["proto"]) for s in c["services"])
+    assert ports == [(88, "tcp"), (389, "tcp"), (464, "tcp"), (636, "tcp")]
+
+
+def test_render_has_generated_header_and_parses():
+    _out, c = gen.derive(INBOUND, INBOUND_PATH)
+    text = gen.render(c)
+    assert text.lstrip().startswith("# GENERATED")
+    assert INBOUND_PATH in text  # source-of-truth pointer in the header
+    parsed = yaml.safe_load(text)
+    assert parsed["generated"] is True
+    assert parsed["target"]["scope"] == "ad-prod"
+
+
+def test_generate_writes_then_is_idempotent(tmp_path):
+    inbound = tmp_path / INBOUND_PATH
+    inbound.parent.mkdir(parents=True, exist_ok=True)
+    inbound.write_text(yaml.safe_dump(INBOUND, sort_keys=False))
+
+    changed = gen.generate(str(tmp_path))
+    out = tmp_path / "scopes/app-payments_env-prod/cross-scope/to-ad.yaml"
+    assert out.exists()
+    assert str(out.relative_to(tmp_path)) in [c.replace(str(tmp_path) + "/", "") for c in changed] or changed
+    # second run changes nothing
+    changed2 = gen.generate(str(tmp_path))
+    assert changed2 == [], f"second run should be idempotent, got {changed2}"
+
+
+def test_check_mode_detects_drift(tmp_path):
+    inbound = tmp_path / INBOUND_PATH
+    inbound.parent.mkdir(parents=True, exist_ok=True)
+    inbound.write_text(yaml.safe_dump(INBOUND, sort_keys=False))
+    # check before generating → drift (missing file)
+    stale = gen.generate(str(tmp_path), check=True)
+    assert stale, "check mode should report the missing courtesy file as drift"
+    # generate, then check → no drift
+    gen.generate(str(tmp_path))
+    assert gen.generate(str(tmp_path), check=True) == []

--- a/action/scripts/tests/test_provision.py
+++ b/action/scripts/tests/test_provision.py
@@ -1,0 +1,172 @@
+"""Tests for provision.py — services provisioning (create/update), ordering, resolution."""
+import os
+
+import yaml
+
+from _loader import load
+
+prov = load("provision.py")
+
+
+class FakeResp:
+    def __init__(self, data, status=200):
+        self._data = data
+        self.status_code = status
+        self.text = ""
+
+    def json(self):
+        return self._data
+
+
+class FakePCE:
+    """Minimal PCE double recording call order and storing draft objects."""
+
+    def __init__(self):
+        self.services = []
+        self.ip_lists = []
+        self.rule_sets = []
+        self.labels = []
+        self.calls = []
+        self._n = 0
+
+    def _href(self, kind):
+        self._n += 1
+        return f"/orgs/1/sec_policy/draft/{kind}/{self._n}"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        if "services" in path:
+            return FakeResp(list(self.services))
+        if "ip_lists" in path:
+            return FakeResp(list(self.ip_lists))
+        if "rule_sets" in path:
+            return FakeResp(list(self.rule_sets))
+        if path == "/labels":
+            return FakeResp(list(self.labels))
+        return FakeResp([])
+
+    def post(self, path, json=None):
+        self.calls.append(("POST", path))
+        if path == "/sec_policy":
+            return FakeResp({"href": "/job/1"}, 201)
+        kind = path.rstrip("/").split("/")[-1]
+        obj = {**(json or {}), "href": self._href(kind)}
+        if "services" in path:
+            self.services.append(obj)
+        elif "ip_lists" in path:
+            self.ip_lists.append(obj)
+        elif "rule_sets" in path:
+            self.rule_sets.append(obj)
+        return FakeResp(obj, 201)
+
+    def put(self, href, json=None):
+        self.calls.append(("PUT", href))
+        return FakeResp({}, 200)
+
+    def delete(self, href):
+        self.calls.append(("DELETE", href))
+        return FakeResp({}, 204)
+
+    def set_credentials(self, *a, **k):
+        pass
+
+    def set_tls_settings(self, *a, **k):
+        pass
+
+
+def test_provision_service_creates_when_absent():
+    pce = FakePCE()
+    action, name = prov.provision_service(
+        pce, "services/postgresql.yaml",
+        {"name": "PostgreSQL", "description": "db", "service_ports": [{"port": 5432, "proto": "tcp"}]},
+    )
+    assert action == "created"
+    assert name == "PostgreSQL"
+    assert pce.services[0]["service_ports"] == [{"port": 5432, "proto": 6}]
+    assert ("POST", "/sec_policy/draft/services") in pce.calls
+
+
+def test_provision_service_updates_when_present():
+    pce = FakePCE()
+    pce.services.append({"name": "PostgreSQL", "href": "/svc/9"})
+    action, name = prov.provision_service(
+        pce, "services/postgresql.yaml",
+        {"name": "PostgreSQL", "service_ports": [{"port": 5432, "proto": "udp"}]},
+    )
+    assert action == "updated"
+    assert ("PUT", "/svc/9") in pce.calls
+
+
+def test_provision_service_maps_udp_proto():
+    pce = FakePCE()
+    prov.provision_service(pce, "services/kerberos.yaml",
+                           {"name": "Kerberos", "service_ports": [{"port": 88, "proto": "udp"}]})
+    assert pce.services[0]["service_ports"] == [{"port": 88, "proto": 17}]
+
+
+def test_delete_object_handles_services():
+    pce = FakePCE()
+    pce.services.append({"name": "PostgreSQL", "href": "/svc/9"})
+    action, name = prov.delete_object(pce, "services/postgresql.yaml")
+    assert action == "deleted"
+    assert ("DELETE", "/svc/9") in pce.calls
+
+
+def test_main_provisions_service_before_ruleset_and_resolves_it(tmp_path, monkeypatch):
+    # A net-new service plus a ruleset that references it by name. The service must
+    # be created first, and the ruleset must resolve the (newly created) service href.
+    (tmp_path / "services").mkdir()
+    (tmp_path / "services" / "postgresql.yaml").write_text(
+        yaml.safe_dump({"name": "PostgreSQL", "service_ports": [{"port": 5432, "proto": "tcp"}]})
+    )
+    rs_dir = tmp_path / "scopes" / "app-shareddb_env-prod" / "inbound"
+    rs_dir.mkdir(parents=True)
+    (rs_dir / "from-payments.yaml").write_text(yaml.safe_dump({
+        "name": "shareddb-inbound-from-payments",
+        "type": "extra-scope",
+        "scopes": [[{"label": {"app": "shareddb"}}, {"label": {"env": "prod"}}]],
+        "rules": [{
+            "name": "payments-to-db",
+            "unscoped_consumers": True,
+            "consumers": [{"label": {"app": "payments"}}],
+            "providers": [{"label": {"role": "db"}}],
+            "services": [{"name": "PostgreSQL"}],
+        }],
+    }))
+
+    pce = FakePCE()
+    monkeypatch.setattr(prov, "get_pce", lambda: pce)
+    monkeypatch.setattr(prov, "build_caches", lambda p: ({}, {}, {}))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CHANGED_FILES", "scopes/app-shareddb_env-prod/inbound/from-payments.yaml\nservices/postgresql.yaml")
+    monkeypatch.setenv("AUTO_PROVISION", "false")  # keep the assertion focused on draft writes
+
+    prov.main()
+
+    # service POST happened before ruleset POST despite the changed-files order
+    svc_post = pce.calls.index(("POST", "/sec_policy/draft/services"))
+    rs_post = pce.calls.index(("POST", "/sec_policy/draft/rule_sets"))
+    assert svc_post < rs_post, f"service must be provisioned before ruleset: {pce.calls}"
+
+    # the ruleset rule resolved the newly created service to its href
+    svc_href = pce.services[0]["href"]
+    assert pce.rule_sets[0]["rules"][0]["ingress_services"] == [{"href": svc_href}]
+
+
+def test_main_skips_generated_courtesy_file(tmp_path, monkeypatch):
+    cs_dir = tmp_path / "scopes" / "app-payments_env-prod" / "cross-scope"
+    cs_dir.mkdir(parents=True)
+    (cs_dir / "to-ad.yaml").write_text(yaml.safe_dump({
+        "generated": True, "name": "payments-to-ad", "type": "extra-scope",
+        "target": {"scope": "ad-prod"},
+    }))
+    pce = FakePCE()
+    monkeypatch.setattr(prov, "get_pce", lambda: pce)
+    monkeypatch.setattr(prov, "build_caches", lambda p: ({}, {}, {}))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CHANGED_FILES", "scopes/app-payments_env-prod/cross-scope/to-ad.yaml")
+    monkeypatch.setenv("AUTO_PROVISION", "false")
+
+    prov.main()
+    # nothing created/updated on the PCE for a generated file
+    assert not any(m == "POST" and "rule_sets" in p for m, p in pce.calls)

--- a/action/scripts/tests/test_security_check.py
+++ b/action/scripts/tests/test_security_check.py
@@ -1,0 +1,140 @@
+"""Tests for security-check.py — focus on SEC-010 provider-centric placement."""
+import os
+
+import yaml
+
+from _loader import load
+
+sc = load("security-check.py")
+
+
+def _rules():
+    rules, exemptions = sc.DEFAULT_RULES, []
+    return rules, exemptions
+
+
+def _write(tmp_path, relpath, data):
+    p = tmp_path / relpath
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(yaml.safe_dump(data, sort_keys=False))
+    return str(p)
+
+
+# --- canonical provider-side file (the real template shape) must pass clean ---
+
+CANONICAL_INBOUND = {
+    "name": "ad-prod-inbound-from-payments",
+    "type": "extra-scope",
+    "enabled": True,
+    "justification": "Payments needs Kerberos/LDAP against AD for PCI role enforcement.",
+    "scopes": [[{"label": {"app": "ad"}}, {"label": {"env": "prod"}}]],
+    "rules": [
+        {
+            "name": "payments-kerberos",
+            "unscoped_consumers": True,
+            "consumers": [{"label": {"app": "payments"}}, {"label": {"role": "processing"}}],
+            "providers": [{"label": {"role": "dc"}}],
+            "services": [{"port": 88, "proto": "tcp"}],
+        }
+    ],
+}
+
+
+def test_sec010_correct_provider_placement_passes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    fp = _write(tmp_path, "scopes/app-ad_env-prod/inbound/from-payments.yaml", CANONICAL_INBOUND)
+    rules, ex = _rules()
+    findings = sc.analyze_file(fp, rules, ex)
+    sec010 = [f for f in findings if f["rule_id"] == "SEC-010"]
+    assert sec010 == [], f"expected no SEC-010 finding on correctly-placed rule, got {sec010}"
+
+
+def test_sec004_does_not_fire_when_justification_present(tmp_path, monkeypatch):
+    # The canonical file carries justification, so SEC-004 must stay silent.
+    monkeypatch.chdir(tmp_path)
+    fp = _write(tmp_path, "scopes/app-ad_env-prod/inbound/from-payments.yaml", CANONICAL_INBOUND)
+    rules, ex = _rules()
+    findings = sc.analyze_file(fp, rules, ex)
+    assert [f for f in findings if f["rule_id"] == "SEC-004"] == []
+
+
+# --- misplacement: rule filed in the consumer's scope (consumer app == scope app) ---
+
+def test_sec010_flags_rule_filed_in_consumer_scope(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    misplaced = dict(CANONICAL_INBOUND)
+    # Same rule but enclosing scope is the *consumer's* (payments) scope — wrong.
+    misplaced = {
+        **CANONICAL_INBOUND,
+        "scopes": [[{"label": {"app": "payments"}}, {"label": {"env": "prod"}}]],
+    }
+    fp = _write(tmp_path, "scopes/app-payments_env-prod/inbound/from-payments.yaml", misplaced)
+    rules, ex = _rules()
+    findings = sc.analyze_file(fp, rules, ex)
+    sec010 = [f for f in findings if f["rule_id"] == "SEC-010"]
+    assert len(sec010) == 1, f"expected one SEC-010 finding, got {sec010}"
+    assert sec010[0]["action"] == "warn"
+    assert sec010[0]["severity"] == "medium"
+
+
+# --- misplacement: providers name a different app than the enclosing scope ---
+
+def test_sec010_flags_provider_app_mismatch(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data = {
+        "name": "wrong",
+        "type": "extra-scope",
+        "scopes": [[{"label": {"app": "ad"}}, {"label": {"env": "prod"}}]],
+        "rules": [
+            {
+                "name": "bad-rule",
+                "unscoped_consumers": True,
+                "consumers": [{"label": {"app": "payments"}}],
+                # providers explicitly name a *different* app than the scope (ad)
+                "providers": [{"label": {"app": "shareddb"}}, {"label": {"role": "db"}}],
+                "services": [{"port": 5432, "proto": "tcp"}],
+            }
+        ],
+    }
+    fp = _write(tmp_path, "scopes/app-ad_env-prod/inbound/from-payments.yaml", data)
+    rules, ex = _rules()
+    findings = sc.analyze_file(fp, rules, ex)
+    sec010 = [f for f in findings if f["rule_id"] == "SEC-010"]
+    assert len(sec010) == 1, f"expected provider-mismatch SEC-010 finding, got {sec010}"
+
+
+# --- legacy requester/target courtesy schema is flagged as deprecated ---
+
+def test_sec010_flags_legacy_requester_target_schema(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    legacy = {
+        "name": "payments-to-ad",
+        "type": "extra-scope",
+        "requester": {"scope": "payments-prod", "consumers": [{"label": {"role": "processing"}}]},
+        "target": {"scope": "ad-prod", "providers": [{"label": {"role": "dc"}}]},
+        "services": [{"port": 88, "proto": "tcp"}],
+        "justification": "x",
+    }
+    fp = _write(tmp_path, "scopes/app-payments_env-prod/cross-scope/to-ad.yaml", legacy)
+    rules, ex = _rules()
+    findings = sc.analyze_file(fp, rules, ex)
+    sec010 = [f for f in findings if f["rule_id"] == "SEC-010"]
+    assert len(sec010) == 1
+    assert "deprecated" in sec010[0]["message"].lower()
+
+
+# --- generated files are skipped entirely ---
+
+def test_generated_file_is_skipped(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    gen = {
+        "generated": True,
+        "name": "payments-to-ad",
+        "type": "extra-scope",
+        "requester": {"scope": "payments-prod"},
+        "target": {"scope": "ad-prod"},
+    }
+    fp = _write(tmp_path, "scopes/app-payments_env-prod/cross-scope/to-ad.yaml", gen)
+    rules, ex = _rules()
+    findings = sc.analyze_file(fp, rules, ex)
+    assert findings == [], f"generated files must not produce findings, got {findings}"

--- a/plugin/plugin.yaml
+++ b/plugin/plugin.yaml
@@ -1,6 +1,6 @@
 apiVersion: plugger/v1
 name: policy-gitops
-version: 0.2.0
+version: 0.3.0
 image: policy-gitops:latest
 
 schedule:

--- a/template/.github/workflows/provision-policy.yml
+++ b/template/.github/workflows/provision-policy.yml
@@ -158,6 +158,18 @@ jobs:
 
             console.log(`Posted provision status on PR #${pr.number}`);
 
+      - name: Regenerate cross-scope docs
+        if: steps.changes.outputs.count != '0'
+        run: |
+          # Provider-centric model: regenerate the read-only requester-side
+          # cross-scope/to-<provider>.yaml views from the canonical inbound files.
+          python3 .github/scripts/generate-cross-scope-docs.py
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add scopes/
+          git diff --staged --quiet || \
+            (git commit -m "chore: regenerate cross-scope docs [skip ci]" && git push)
+
       - name: Update README badges
         if: steps.changes.outputs.count != '0'
         run: |
@@ -168,8 +180,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add README.md
           git diff --staged --quiet || \
-            git commit -m "chore: update policy badges [skip ci]" && \
-            git push
+            (git commit -m "chore: update policy badges [skip ci]" && git push)
 
       - name: Fail if provision errored
         if: steps.provision.outcome == 'failure'

--- a/template/.illumio/security-rules.yaml
+++ b/template/.illumio/security-rules.yaml
@@ -85,6 +85,18 @@ rules:
     ports: [80]
     description: "Consider requiring HTTPS (443) instead of HTTP (80)"
 
+  - id: SEC-010
+    name: "Extra-scope rule provider-centric placement"
+    severity: medium
+    action: warn
+    description: >
+      Scopes are provider-centric: a cross-scope (extra-scope) rule protects the
+      provider's workloads, so it must be authored in the provider's scope
+      (scopes/app-<provider>_env-<env>/inbound/from-<requester>.yaml). Flags rules
+      whose consumer app equals the enclosing scope, or whose providers name a
+      different app than the scope. Also flags the deprecated requester/target
+      courtesy schema (the requester-side file is generated, not authored).
+
 # Exemptions: bypass specific rules for matching rulesets or scopes
 exemptions:
   - ruleset_pattern: "coreservices"

--- a/template/CODEOWNERS
+++ b/template/CODEOWNERS
@@ -9,11 +9,17 @@ services/               @org/security-team
 .illumio/               @org/security-team
 
 # Per-scope ownership — each team owns their application scope
-# scopes/payments-prod/   @org/payments-team
-# scopes/shareddb-prod/   @org/database-team
-# scopes/ordering-prod/   @org/ordering-team
-# scopes/frontend-prod/   @org/frontend-team
+# scopes/app-payments_env-prod/   @org/payments-team
+# scopes/app-shareddb_env-prod/   @org/database-team
+# scopes/app-ordering_env-prod/   @org/ordering-team
+# scopes/app-frontend_env-prod/   @org/frontend-team
 
-# Cross-scope rules always require security team review
-scopes/*/cross-scope/   @org/security-team
+# Cross-scope rules are provider-centric: the canonical rule is authored in the
+# PROVIDER's scope under inbound/. The provider scope owner (matched by the
+# per-scope line above) plus security must approve it; the requester is the PR
+# author. Security reviews all cross-scope changes.
 scopes/*/inbound/       @org/security-team
+
+# cross-scope/ holds GENERATED, read-only requester-side views (generated: true).
+# They are regenerated on merge and not authored by hand — security owns them.
+scopes/*/cross-scope/   @org/security-team

--- a/template/scopes/app-ad_env-prod/inbound/from-payments.yaml
+++ b/template/scopes/app-ad_env-prod/inbound/from-payments.yaml
@@ -3,6 +3,18 @@ description: "Inbound from payments scope — AD authentication for payment proc
 type: extra-scope
 enabled: true
 
+# Provider-centric model: this file (in the AD scope) is the single source of
+# truth for the payments→AD dependency. The AD team + security own and approve it;
+# payments is the PR author. The requester-side scopes/app-payments_env-prod/
+# cross-scope/to-ad.yaml is GENERATED from this file for discoverability.
+justification: >
+  Payment processing workloads use Kerberos authentication for service accounts
+  and LDAP to validate group membership for PCI-DSS role enforcement.
+  LDAPS (636) is required; plaintext LDAP (389) is used only for initial
+  configuration discovery and will be removed after migration is complete.
+requested_by: alice@example.com
+requested_date: "2026-04-15"
+
 scopes:
   - - label: {app: ad}
     - label: {env: prod}

--- a/template/scopes/app-payments_env-prod/cross-scope/to-ad.yaml
+++ b/template/scopes/app-payments_env-prod/cross-scope/to-ad.yaml
@@ -1,29 +1,38 @@
-name: payments-to-ad
-description: "Payments processing workloads authenticate against production Active Directory"
-type: extra-scope
-enabled: true
+# GENERATED FILE — DO NOT EDIT.
+# Source of truth: scopes/app-ad_env-prod/inbound/from-payments.yaml
+# Regenerate: python3 .github/scripts/generate-cross-scope-docs.py
 
+generated: true
+name: payments-to-ad
+description: 'Generated cross-scope dependency: payments → ad. See source.'
+type: extra-scope
+source: scopes/app-ad_env-prod/inbound/from-payments.yaml
 requester:
   scope: payments-prod
   consumers:
-    - label: {role: processing}
-
+  - label:
+      role: processing
 target:
   scope: ad-prod
   providers:
-    - label: {role: dc}
-
+  - label:
+      role: dc
 services:
-  - {port: 88, proto: tcp}     # Kerberos
-  - {port: 88, proto: udp}
-  - {port: 389, proto: tcp}    # LDAP
-  - {port: 636, proto: tcp}    # LDAPS (preferred)
-  - {port: 464, proto: tcp}    # kpasswd
+- port: 88
+  proto: tcp
+- port: 88
+  proto: udp
+- port: 464
+  proto: tcp
+- port: 389
+  proto: tcp
+- port: 636
+  proto: tcp
+justification: 'Payment processing workloads use Kerberos authentication for service
+  accounts and LDAP to validate group membership for PCI-DSS role enforcement. LDAPS
+  (636) is required; plaintext LDAP (389) is used only for initial configuration discovery
+  and will be removed after migration is complete.
 
-justification: >
-  Payment processing workloads use Kerberos authentication for service accounts
-  and LDAP to validate group membership for PCI-DSS role enforcement.
-  LDAPS (636) is required; plaintext LDAP (389) is used only for initial
-  configuration discovery and will be removed after migration is complete.
+  '
 requested_by: alice@example.com
-requested_date: "2026-04-15"
+requested_date: '2026-04-15'

--- a/workflow/plugin.yaml
+++ b/workflow/plugin.yaml
@@ -1,6 +1,6 @@
 apiVersion: plugger/v1
 name: policy-workflow
-version: 0.2.0
+version: 0.3.0
 image: policy-workflow:latest
 
 schedule:


### PR DESCRIPTION
## Summary

Two related changes to the GitOps authoring model, driven by the insight that **Illumio scopes are provider-centric** — an extra-scope rule protects the provider's workloads, so it belongs in the provider's scope.

### 1. Provider-centric cross-scope authoring (commit 1)

Cross-scope dependencies are now authored **once**, in the provider's scope:

```
scopes/app-<provider>_env-<env>/inbound/from-<requester>.yaml   ← canonical, provisioned
scopes/app-<requester>_env-<env>/cross-scope/to-<provider>.yaml ← GENERATED, read-only
```

The old two-file model required a redundant requester-side file that was never provisioned (`provision.py` already skipped it for lacking top-level `rules:`). The requester-side view is now derived by `generate-cross-scope-docs.py` and regenerated + committed on merge.

- **Approval falls out of the data model:** provider team (CODEOWNERS on `inbound/`) + security approve. The requester is the PR author — their consent is implicit.
- **SEC-010 (warn / medium)** enforces placement: flags rules whose consumer app equals the enclosing scope, or whose providers name a different app than the scope, plus the deprecated `requester:`/`target:` hand-authored schema.
- Generated files carry `generated: true` and are skipped by `security-check.py` / `provision.py`.
- Template migrated: `justification` / `requested_by` / `requested_date` now live on the canonical inbound file — also fixes a **latent SEC-004 false-warning** that fired on inbound files lacking justification.
- MINOR version bump on `plugin/plugin.yaml` and `workflow/plugin.yaml` per CONTRIBUTING (new SEC rule = MINOR).

### 2. Services provisioning fix (commit 2)

`provision.py` previously only routed `ip-lists/` and `scopes/`. A net-new named service authored in Git was never created on the PCE, and any rule referencing it by name failed resolution — a hole in the "Git is the source of truth" story.

- New `provision_service` (create-or-update by name against PCE draft) + `services/` routing.
- File ordering: `ip-lists/` + `services/` provisioned **before** `scopes/` so rules resolve to draft hrefs.
- `_refresh_service_cache` merges newly-created draft services into `svc_map` before rulesets are processed.
- `delete_object` handles `services/` deletions.

## After this PR, the GitOps-only path creates all object types on the PCE

| Object | Before | After |
|---|---|---|
| IP lists | ✅ | ✅ |
| Rulesets | ✅ | ✅ |
| Rules (in a ruleset) | ✅ | ✅ |
| **Services** | ❌ | ✅ |

## Tests

`action/scripts/tests/` — 18 tests, all passing:

- `test_security_check.py` (6): SEC-010 placement correct/misplaced/provider-mismatch, legacy schema flagged, generated files skipped, SEC-004 silent when justification present.
- `test_generate_cross_scope.py` (6): derive paths/scopes/actors, services union, GENERATED header, idempotent regeneration, `--check` drift detection.
- `test_provision.py` (6): create/update/proto-mapping, service deletion, integration (service POST before ruleset POST, newly-created service resolved by ruleset rule), generated-file skip.

Regression scan across the full template (12 files): no new findings — only the 3 pre-existing non-blocking warnings (broad reference IP lists + AD SMB).

## Reviewer notes

- The `cross-scope/` directory and CODEOWNERS line for it are kept; only the **contents** change (now generated). Security still owns the path.
- Requester environment is assumed to match the provider's during generation. Revisit if cross-env dependencies become a thing.
- Follow-up tracked in `TODO.md`: `plugin/main.py`'s `import_yaml_to_*` functions are dead code (no callers; no PCE writes) — decide whether to wire `SYNC_MODE=provision` to them or remove the converters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)